### PR TITLE
Fixed typo in linked URL

### DIFF
--- a/Notebooks/PySpark/Synapse Link for Cosmos DB samples/IoT/README.md
+++ b/Notebooks/PySpark/Synapse Link for Cosmos DB samples/IoT/README.md
@@ -12,11 +12,11 @@ Please make sure that you followed the pre-reqs of the main [README](../README.m
 
 3. Using the Azure Portal, go to Data Explorer of your the Azure Cosmos DB Account and create a database called CosmosDBIoTDemo. 
 
-4. In the same Data Explorer, create two Analytical Store enabled containers: IoTSignals and IoTDeviceInfo. In the portal interface, the container-id is the container name. Change the Throughput to Autoscale and set the max limit to 4,000. Please click [here](https://review.docs.microsoft.com/en-us/azure/cosmos-db/configure-synapse-link?branch=release-build-cosmosdb#create-analytical-ttl) for details on how to enable Analytical storage on Cosmos DB containers.
+4. In the same Data Explorer, create two Analytical Store enabled containers: IoTSignals and IoTDeviceInfo. In the portal interface, the container-id is the container name. Change the Throughput to Autoscale and set the max limit to 4,000. Please click [here](https://docs.microsoft.com/en-us/azure/cosmos-db/configure-synapse-link?branch=release-build-cosmosdb#create-analytical-ttl) for details on how to enable Analytical storage on Cosmos DB containers.
     * Use /id as the Partition key for both the containers
     * Please make sure that Analytical store is enabled for both the containers
 
-5. In your Azure Synapse workspace, go to the Manage / Linked Services tab and create a linked service called CosmosDBIoTDemo pointing to the Cosmos DB database that was created in step 3 above. Please click [here](https://review.docs.microsoft.com/en-us/azure/synapse-analytics/synapse-link/how-to-connect-synapse-link-cosmos-db?branch=release-build-synapse#connect-an-azure-cosmos-db-database-to-a-synapse-workspace) for more details on creating Synapse linked service pointing to Cosmos DB.
+5. In your Azure Synapse workspace, go to the Manage / Linked Services tab and create a linked service called CosmosDBIoTDemo pointing to the Cosmos DB database that was created in step 3 above. Please click [here](https://docs.microsoft.com/en-us/azure/synapse-analytics/synapse-link/how-to-connect-synapse-link-cosmos-db?branch=release-build-synapse#connect-an-azure-cosmos-db-database-to-a-synapse-workspace) for more details on creating Synapse linked service pointing to Cosmos DB.
 
 ### Notebooks Execution
 

--- a/Notebooks/PySpark/Synapse Link for Cosmos DB samples/IoT/README.md
+++ b/Notebooks/PySpark/Synapse Link for Cosmos DB samples/IoT/README.md
@@ -12,11 +12,11 @@ Please make sure that you followed the pre-reqs of the main [README](../README.m
 
 3. Using the Azure Portal, go to Data Explorer of your the Azure Cosmos DB Account and create a database called CosmosDBIoTDemo. 
 
-4. In the same Data Explorer, create two Analytical Store enabled containers: IoTSignals and IoTDeviceInfo. In the portal interface, the container-id is the container name. Change the Throughput to Autoscale and set the max limit to 4,000. Please click [here](https://docs.microsoft.com/en-us/azure/cosmos-db/configure-synapse-link?branch=release-build-cosmosdb#create-analytical-ttl) for details on how to enable Analytical storage on Cosmos DB containers.
+4. In the same Data Explorer, create two Analytical Store enabled containers: IoTSignals and IoTDeviceInfo. In the portal interface, the container-id is the container name. Change the Throughput to Autoscale and set the max limit to 4,000. Please click [here](https://docs.microsoft.com/en-us/azure/cosmos-db/configure-synapse-link#create-analytical-ttl) for details on how to enable Analytical storage on Cosmos DB containers.
     * Use /id as the Partition key for both the containers
     * Please make sure that Analytical store is enabled for both the containers
 
-5. In your Azure Synapse workspace, go to the Manage / Linked Services tab and create a linked service called CosmosDBIoTDemo pointing to the Cosmos DB database that was created in step 3 above. Please click [here](https://docs.microsoft.com/en-us/azure/synapse-analytics/synapse-link/how-to-connect-synapse-link-cosmos-db?branch=release-build-synapse#connect-an-azure-cosmos-db-database-to-a-synapse-workspace) for more details on creating Synapse linked service pointing to Cosmos DB.
+5. In your Azure Synapse workspace, go to the Manage / Linked Services tab and create a linked service called CosmosDBIoTDemo pointing to the Cosmos DB database that was created in step 3 above. Please click [here](https://docs.microsoft.com/en-us/azure/synapse-analytics/synapse-link/how-to-connect-synapse-link-cosmos-db#connect-an-azure-cosmos-db-database-to-a-synapse-workspace) for more details on creating Synapse linked service pointing to Cosmos DB.
 
 ### Notebooks Execution
 

--- a/Notebooks/PySpark/Synapse Link for Cosmos DB samples/IoT/spark-notebooks/pyspark/01-CosmosDBSynapseStreamIngestion.ipynb
+++ b/Notebooks/PySpark/Synapse Link for Cosmos DB samples/IoT/spark-notebooks/pyspark/01-CosmosDBSynapseStreamIngestion.ipynb
@@ -20,12 +20,12 @@
         "2. Format the stream dataframe as per the IoTSignals schema\n",
         "3. Write the streaming dataframe to the Azure Cosmos DB collection\n",
         "\n",
-        ">**Did you know?** Azure Cosmos DB is a great fit for IoT predictive maintenance and anomaly detection use cases. [Click here](https://review.docs.microsoft.com/en-us/azure/cosmos-db/synapse-link-use-cases?branch=release-build-cosmosdb#iot-predictive-maintenance) to learn more about an IoT architecture leveraging HTAP capabilities of Azure Synapse Link for Azure Cosmos DB.\n",
+        ">**Did you know?** Azure Cosmos DB is a great fit for IoT predictive maintenance and anomaly detection use cases. [Click here](https://docs.microsoft.com/en-us/azure/cosmos-db/synapse-link-use-cases#iot-predictive-maintenance) to learn more about an IoT architecture leveraging HTAP capabilities of Azure Synapse Link for Azure Cosmos DB.\n",
         "\n",
-        ">**Did you know?**  [Azure Synapse Link for Azure Cosmos DB](https://review.docs.microsoft.com/en-us/azure/cosmos-db/synapse-link?branch=release-build-cosmosdb) is a hybrid transactional and analytical processing (HTAP) capability that enables you to run near real-time analytics over operational data in Azure Cosmos DB.\n",
+        ">**Did you know?**  [Azure Synapse Link for Azure Cosmos DB](https://docs.microsoft.com/en-us/azure/cosmos-db/synapse-link) is a hybrid transactional and analytical processing (HTAP) capability that enables you to run near real-time analytics over operational data in Azure Cosmos DB.\n",
         "&nbsp;\n",
         "\n",
-        ">**Did you know?**  [Azure Cosmos DB analytical store](https://review.docs.microsoft.com/en-us/azure/cosmos-db/analytical-store-introduction?branch=release-build-cosmosdb) is a fully isolated column store for enabling large scale analytics against operational data in your Azure Cosmos DB, without any impact to your transactional workloads.\n",
+        ">**Did you know?**  [Azure Cosmos DB analytical store](https://docs.microsoft.com/en-us/azure/cosmos-db/analytical-store-introduction) is a fully isolated column store for enabling large scale analytics against operational data in your Azure Cosmos DB, without any impact to your transactional workloads.\n",
         "&nbsp;"
       ],
       "attachments": {}

--- a/Notebooks/PySpark/Synapse Link for Cosmos DB samples/IoT/spark-notebooks/pyspark/02-CosmosDBSynapseBatchIngestion.ipynb
+++ b/Notebooks/PySpark/Synapse Link for Cosmos DB samples/IoT/spark-notebooks/pyspark/02-CosmosDBSynapseBatchIngestion.ipynb
@@ -19,12 +19,11 @@
         "1. Load the IoTDeviceInfo dataset from ADLS Gen2 to a dataframe\n",
         "2. Write the dataframe to the Azure Cosmos DB collection\n",
         "\n",
-        ">**Did you know?**  [Azure Synapse Link for Azure Cosmos DB](https://review.docs.microsoft.com/en-us/azure/cosmos-db/synapse-link?branch=release-build-cosmosdb) is a hybrid transactional and analytical processing (HTAP) capability that enables you to run near real-time analytics over operational data in Azure Cosmos DB.\n",
+        ">**Did you know?**  [Azure Synapse Link for Azure Cosmos DB](https://docs.microsoft.com/en-us/azure/cosmos-db/synapse-link) is a hybrid transactional and analytical processing (HTAP) capability that enables you to run near real-time analytics over operational data in Azure Cosmos DB.\n",
         "&nbsp;\n",
         "\n",
-        ">**Did you know?**  [Azure Cosmos DB analytical store](https://review.docs.microsoft.com/en-us/azure/cosmos-db/analytical-store-introduction?branch=release-build-cosmosdb) is a fully isolated column store for enabling large scale analytics against operational data in your Azure Cosmos DB, without any impact to your transactional workloads.\n",
-        "&nbsp;\n",
-        ""
+        ">**Did you know?**  [Azure Cosmos DB analytical store](https://docs.microsoft.com/en-us/azure/cosmos-db/analytical-store-introduction) is a fully isolated column store for enabling large scale analytics against operational data in your Azure Cosmos DB, without any impact to your transactional workloads.\n",
+        "&nbsp;\n"
       ],
       "attachments": {}
     },

--- a/Notebooks/PySpark/Synapse Link for Cosmos DB samples/IoT/spark-notebooks/pyspark/03-CosmosDBSynapseJoins.ipynb
+++ b/Notebooks/PySpark/Synapse Link for Cosmos DB samples/IoT/spark-notebooks/pyspark/03-CosmosDBSynapseJoins.ipynb
@@ -15,18 +15,17 @@
         "# Joins and aggregations across Azure Cosmos DB collections using Azure Synapse Link \n",
         "In this notebook, we'll \n",
         "\n",
-        "1. Create Spark tables pointing to [Azure Cosmos DB Analytical store](https://review.docs.microsoft.com/en-us/azure/cosmos-db/analytical-store-introduction?branch=release-build-cosmosdb) collections\n",
+        "1. Create Spark tables pointing to [Azure Cosmos DB Analytical store](https://docs.microsoft.com/en-us/azure/cosmos-db/analytical-store-introduction) collections\n",
         "2. Perform Joins, filters and aggregations across collections using Spark-SQL\n",
         "3. Visualize the data using plotly and displayHTML()\n",
         "\n",
-        ">**Did you know?**  [Azure Synapse Link for Azure Cosmos DB](https://review.docs.microsoft.com/en-us/azure/cosmos-db/synapse-link?branch=release-build-cosmosdb) is a hybrid transactional and analytical processing (HTAP) capability that enables you to run near real-time analytics over operational data in Azure Cosmos DB.\n",
+        ">**Did you know?**  [Azure Synapse Link for Azure Cosmos DB](https://docs.microsoft.com/en-us/azure/cosmos-db/synapse-link) is a hybrid transactional and analytical processing (HTAP) capability that enables you to run near real-time analytics over operational data in Azure Cosmos DB.\n",
         "&nbsp;\n",
         "\n",
-        ">**Did you know?**  [Azure Cosmos DB analytical store](https://review.docs.microsoft.com/en-us/azure/cosmos-db/analytical-store-introduction?branch=release-build-cosmosdb) is a fully isolated column store for enabling large scale analytics against operational data in your Azure Cosmos DB, without any impact to your transactional workloads.\n",
+        ">**Did you know?**  [Azure Cosmos DB analytical store](https://docs.microsoft.com/en-us/azure/cosmos-db/analytical-store-introduction) is a fully isolated column store for enabling large scale analytics against operational data in your Azure Cosmos DB, without any impact to your transactional workloads.\n",
         "&nbsp;\n",
         "\n",
-        ">**Did you know?**  Spark tables created on top of Azure Cosmos DB Collections are metadata tables, passing the queries to the corresponding collections.\n",
-        ""
+        ">**Did you know?**  Spark tables created on top of Azure Cosmos DB Collections are metadata tables, passing the queries to the corresponding collections.\n"
       ],
       "attachments": {}
     },
@@ -39,7 +38,7 @@
         "\n",
         ">**Did you know?**  The Cosmos DB Linked Service in Synapse abstracts the connection configs for the Azure Cosmos DB Database. \n",
         "\n",
-        ">[Click here](https://review.docs.microsoft.com/en-us/azure/synapse-analytics/synapse-link/how-to-connect-synapse-link-cosmos-db?branch=release-build-synapse#connect-an-azure-cosmos-db-database-to-a-synapse-workspace) to learn how to setup a Linked Service to connect Azure Cosmos DB database to the Azure Synapse workspace"
+        ">[Click here](https://docs.microsoft.com/en-us/azure/synapse-analytics/synapse-link/how-to-connect-synapse-link-cosmos-db#connect-an-azure-cosmos-db-database-to-a-synapse-workspace) to learn how to setup a Linked Service to connect Azure Cosmos DB database to the Azure Synapse workspace"
       ],
       "attachments": {}
     },

--- a/Notebooks/PySpark/Synapse Link for Cosmos DB samples/IoT/spark-notebooks/pyspark/04-CosmosDBSynapseML.ipynb
+++ b/Notebooks/PySpark/Synapse Link for Cosmos DB samples/IoT/spark-notebooks/pyspark/04-CosmosDBSynapseML.ipynb
@@ -21,14 +21,13 @@
         "&nbsp;\n",
         "In this notebook, we'll \n",
         "\n",
-        "1. Loda the data in [Cosmos DB Analytical store](https://review.docs.microsoft.com/en-us/azure/cosmos-db/analytical-store-introduction?branch=release-build-cosmosdb) collection into a Dataframe\n",
+        "1. Loda the data in [Cosmos DB Analytical store](https://docs.microsoft.com/en-us/azure/cosmos-db/analytical-store-introduction) collection into a Dataframe\n",
         "2. Perform data exploration using pyplot\n",
         "2. Perform anomaly detection using [Azure Cognitive Services on Spark](https://mmlspark.blob.core.windows.net/website/index.html)\n",
         "3. Visualize the anomalies using plotly\n",
         "\n",
         "\n",
-        ">**Did you know?**  [MMLSpark](https://github.com/Azure/mmlspark) (Azure Cognitive Services on Spark) is an ecosystem of tools making use of the  distributed computing capability of Apache Spark and includes seamless integration of Spark Machine Learning pipelines with Microsoft Cognitive Toolkit (CNTK), LightGBM and OpenCV.\n",
-        ""
+        ">**Did you know?**  [MMLSpark](https://github.com/Azure/mmlspark) (Azure Cognitive Services on Spark) is an ecosystem of tools making use of the  distributed computing capability of Apache Spark and includes seamless integration of Spark Machine Learning pipelines with Microsoft Cognitive Toolkit (CNTK), LightGBM and OpenCV.\n"
       ],
       "attachments": {}
     },

--- a/Notebooks/PySpark/Synapse Link for Cosmos DB samples/IoT/spark-notebooks/pyspark/1CosmosDBSynapseStreamIngestion.ipynb
+++ b/Notebooks/PySpark/Synapse Link for Cosmos DB samples/IoT/spark-notebooks/pyspark/1CosmosDBSynapseStreamIngestion.ipynb
@@ -20,12 +20,12 @@
         "2. Format the stream dataframe as per the IoTSignals schema\n",
         "3. Write the streaming dataframe to the Azure Cosmos DB collection\n",
         "\n",
-        ">**Did you know?** Azure Cosmos DB is a great fit for IoT predictive maintenance and anomaly detection use cases. [Click here](https://review.docs.microsoft.com/en-us/azure/cosmos-db/synapse-link-use-cases?branch=release-build-cosmosdb#iot-predictive-maintenance) to learn more about an IoT architecture leveraging HTAP capabilities of Azure Synapse Link for Azure Cosmos DB.\n",
+        ">**Did you know?** Azure Cosmos DB is a great fit for IoT predictive maintenance and anomaly detection use cases. [Click here](https://docs.microsoft.com/en-us/azure/cosmos-db/synapse-link-use-cases#iot-predictive-maintenance) to learn more about an IoT architecture leveraging HTAP capabilities of Azure Synapse Link for Azure Cosmos DB.\n",
         "\n",
-        ">**Did you know?**  [Azure Synapse Link for Azure Cosmos DB](https://review.docs.microsoft.com/en-us/azure/cosmos-db/synapse-link?branch=release-build-cosmosdb) is a hybrid transactional and analytical processing (HTAP) capability that enables you to run near real-time analytics over operational data in Azure Cosmos DB.\n",
+        ">**Did you know?**  [Azure Synapse Link for Azure Cosmos DB](https://docs.microsoft.com/en-us/azure/cosmos-db/synapse-link) is a hybrid transactional and analytical processing (HTAP) capability that enables you to run near real-time analytics over operational data in Azure Cosmos DB.\n",
         "&nbsp;\n",
         "\n",
-        ">**Did you know?**  [Azure Cosmos DB analytical store](https://review.docs.microsoft.com/en-us/azure/cosmos-db/analytical-store-introduction?branch=release-build-cosmosdb) is a fully isolated column store for enabling large scale analytics against operational data in your Azure Cosmos DB, without any impact to your transactional workloads.\n",
+        ">**Did you know?**  [Azure Cosmos DB analytical store](https://docs.microsoft.com/en-us/azure/cosmos-db/analytical-store-introduction?branch=release-build-cosmosdb) is a fully isolated column store for enabling large scale analytics against operational data in your Azure Cosmos DB, without any impact to your transactional workloads.\n",
         "&nbsp;"
       ],
       "attachments": {}

--- a/Notebooks/PySpark/Synapse Link for Cosmos DB samples/IoT/spark-notebooks/pyspark/2CosmosDBSynapseBatchIngestion.ipynb
+++ b/Notebooks/PySpark/Synapse Link for Cosmos DB samples/IoT/spark-notebooks/pyspark/2CosmosDBSynapseBatchIngestion.ipynb
@@ -19,12 +19,11 @@
         "1. Load the IoTDeviceInfo dataset from ADLS Gen2 to a dataframe\n",
         "2. Write the dataframe to the Azure Cosmos DB collection\n",
         "\n",
-        ">**Did you know?**  [Azure Synapse Link for Azure Cosmos DB](https://review.docs.microsoft.com/en-us/azure/cosmos-db/synapse-link?branch=release-build-cosmosdb) is a hybrid transactional and analytical processing (HTAP) capability that enables you to run near real-time analytics over operational data in Azure Cosmos DB.\n",
+        ">**Did you know?**  [Azure Synapse Link for Azure Cosmos DB](https://docs.microsoft.com/en-us/azure/cosmos-db/synapse-link) is a hybrid transactional and analytical processing (HTAP) capability that enables you to run near real-time analytics over operational data in Azure Cosmos DB.\n",
         "&nbsp;\n",
         "\n",
-        ">**Did you know?**  [Azure Cosmos DB analytical store](https://review.docs.microsoft.com/en-us/azure/cosmos-db/analytical-store-introduction?branch=release-build-cosmosdb) is a fully isolated column store for enabling large scale analytics against operational data in your Azure Cosmos DB, without any impact to your transactional workloads.\n",
-        "&nbsp;\n",
-        ""
+        ">**Did you know?**  [Azure Cosmos DB analytical store](https://docs.microsoft.com/en-us/azure/cosmos-db/analytical-store-introduction) is a fully isolated column store for enabling large scale analytics against operational data in your Azure Cosmos DB, without any impact to your transactional workloads.\n",
+        "&nbsp;\n"
       ],
       "attachments": {}
     },

--- a/Notebooks/PySpark/Synapse Link for Cosmos DB samples/IoT/spark-notebooks/pyspark/3CosmosDBSynapseJoins.ipynb
+++ b/Notebooks/PySpark/Synapse Link for Cosmos DB samples/IoT/spark-notebooks/pyspark/3CosmosDBSynapseJoins.ipynb
@@ -15,18 +15,17 @@
         "# Joins and aggregations across Azure Cosmos DB collections using Azure Synapse Link \n",
         "In this notebook, we'll \n",
         "\n",
-        "1. Create Spark tables pointing to [Azure Cosmos DB Analytical store](https://review.docs.microsoft.com/en-us/azure/cosmos-db/analytical-store-introduction?branch=release-build-cosmosdb) collections\n",
+        "1. Create Spark tables pointing to [Azure Cosmos DB Analytical store](https://docs.microsoft.com/en-us/azure/cosmos-db/analytical-store-introduction) collections\n",
         "2. Perform Joins, filters and aggregations across collections using Spark-SQL\n",
         "3. Visualize the data using plotly and displayHTML()\n",
         "\n",
-        ">**Did you know?**  [Azure Synapse Link for Azure Cosmos DB](https://review.docs.microsoft.com/en-us/azure/cosmos-db/synapse-link?branch=release-build-cosmosdb) is a hybrid transactional and analytical processing (HTAP) capability that enables you to run near real-time analytics over operational data in Azure Cosmos DB.\n",
+        ">**Did you know?**  [Azure Synapse Link for Azure Cosmos DB](https://docs.microsoft.com/en-us/azure/cosmos-db/synapse-link) is a hybrid transactional and analytical processing (HTAP) capability that enables you to run near real-time analytics over operational data in Azure Cosmos DB.\n",
         "&nbsp;\n",
         "\n",
-        ">**Did you know?**  [Azure Cosmos DB analytical store](https://review.docs.microsoft.com/en-us/azure/cosmos-db/analytical-store-introduction?branch=release-build-cosmosdb) is a fully isolated column store for enabling large scale analytics against operational data in your Azure Cosmos DB, without any impact to your transactional workloads.\n",
+        ">**Did you know?**  [Azure Cosmos DB analytical store](https://docs.microsoft.com/en-us/azure/cosmos-db/analytical-store-introduction) is a fully isolated column store for enabling large scale analytics against operational data in your Azure Cosmos DB, without any impact to your transactional workloads.\n",
         "&nbsp;\n",
         "\n",
-        ">**Did you know?**  Spark tables created on top of Azure Cosmos DB Collections are metadata tables, passing the queries to the corresponding collections.\n",
-        ""
+        ">**Did you know?**  Spark tables created on top of Azure Cosmos DB Collections are metadata tables, passing the queries to the corresponding collections.\n"
       ],
       "attachments": {}
     },
@@ -39,7 +38,7 @@
         "\n",
         ">**Did you know?**  The Cosmos DB Linked Service in Synapse abstracts the connection configs for the Azure Cosmos DB Database. \n",
         "\n",
-        ">[Click here](https://review.docs.microsoft.com/en-us/azure/synapse-analytics/synapse-link/how-to-connect-synapse-link-cosmos-db?branch=release-build-synapse#connect-an-azure-cosmos-db-database-to-a-synapse-workspace) to learn how to setup a Linked Service to connect Azure Cosmos DB database to the Azure Synapse workspace"
+        ">[Click here](https://docs.microsoft.com/en-us/azure/synapse-analytics/synapse-link/how-to-connect-synapse-link-cosmos-db#connect-an-azure-cosmos-db-database-to-a-synapse-workspace) to learn how to setup a Linked Service to connect Azure Cosmos DB database to the Azure Synapse workspace"
       ],
       "attachments": {}
     },

--- a/Notebooks/PySpark/Synapse Link for Cosmos DB samples/IoT/spark-notebooks/pyspark/4CosmosDBSynapseML.ipynb
+++ b/Notebooks/PySpark/Synapse Link for Cosmos DB samples/IoT/spark-notebooks/pyspark/4CosmosDBSynapseML.ipynb
@@ -21,14 +21,13 @@
         "&nbsp;\n",
         "In this notebook, we'll \n",
         "\n",
-        "1. Loda the data in [Cosmos DB Analytical store](https://review.docs.microsoft.com/en-us/azure/cosmos-db/analytical-store-introduction?branch=release-build-cosmosdb) collection into a Dataframe\n",
+        "1. Loda the data in [Cosmos DB Analytical store](https://docs.microsoft.com/en-us/azure/cosmos-db/analytical-store-introduction) collection into a Dataframe\n",
         "2. Perform data exploration using pyplot\n",
         "2. Perform anomaly detection using [Azure Cognitive Services on Spark](https://mmlspark.blob.core.windows.net/website/index.html)\n",
         "3. Visualize the anomalies using plotly\n",
         "\n",
         "\n",
-        ">**Did you know?**  [MMLSpark](https://github.com/Azure/mmlspark) (Azure Cognitive Services on Spark) is an ecosystem of tools making use of the  distributed computing capability of Apache Spark and includes seamless integration of Spark Machine Learning pipelines with Microsoft Cognitive Toolkit (CNTK), LightGBM and OpenCV.\n",
-        ""
+        ">**Did you know?**  [MMLSpark](https://github.com/Azure/mmlspark) (Azure Cognitive Services on Spark) is an ecosystem of tools making use of the  distributed computing capability of Apache Spark and includes seamless integration of Spark Machine Learning pipelines with Microsoft Cognitive Toolkit (CNTK), LightGBM and OpenCV.\n"
       ],
       "attachments": {}
     },


### PR DESCRIPTION
Since there is a link for review that seems to be viewable only by Microsoft employees, I replaced it with the link of the published document.