### PR TITLE
Adding the btrim, ltrim, rtrim functions for version 0.9.0.0 of the Synapse SQL Extension toolkit

### DIFF
--- a/SQL/Extension/Readme.md
+++ b/SQL/Extension/Readme.md
@@ -1,25 +1,43 @@
 # Azure Synapse SQL Extension
 
-The Azure Synapse SQL Extension contain a collection of User Defined Functions (UDFs) and Views that extend the capabilities of Azure Synapse SQL. 
+The Azure Synapse SQL Extension contain a collection of User Defined Functions (UDFs) and Views that extend the capabilities of Azure Synapse SQL.
 
 ## Schemas
-The Azure Synapse SQL Extension will install the `microsoft` schema to your Synapse SQL pool. 
+
+The Azure Synapse SQL Extension will install the `microsoft` schema to your Synapse SQL pool.
 
 ## Functions
+
 The Azure Synapse SQL Extension will install a collection of functions to your Synapse SQL pool. These functions extend the SQL capabilties by providing support for ANSI or Teradata functions. To see the complete list of functions, visit the [Functions Readme](functions/Readme.md)
 
 ## Views
+
 The Azure Synapse SQL Extension will install a collection of vies to your Synapse SQL pool. These views extend the SQL monitoring capabilities by providing deeper insight into the configuration and execution of the Synapse SQL pool. To see the complete list of views, visit the [Views Readme](views/Readme.md)
 
 ## Installation
+
 1. Download the latest release of the *Azure Synapse SQL Extension* toolkit
 2. From a command prompt, execute the `deploy.bat` file providing the following details:
    - *server_name*: The name of the Azure Synapse SQL server.
    - *database_name*: The name of the Azure Synapse SQL server.
    - *user_name*: The user name to connect with.
-   - *password*: The password to connect with. 
+   - *password*: The password to connect with.
 
 ### Deployment Example
+
 `
-.\deploy.bat demo.database.windows.net SampleDW sa very_secure_password
+.\deploy.bat demo.database.windows.net DemoDW cloudsa very_secure_password
 `
+
+## Version History
+
+### v0.9.0.0 (September 2nd, 2020)
+Version 0.9.0.0 adds the following:
+
+- [Function]: The `microsoft.btrim` script installs a function that emulates the `TRIM(BOTH 'trim_characters' FROM expression)` Teradata function.
+- [Function]: The `microsoft.ltrim` script installs a function that emulates the `TRIM(LEADING 'trim_characters' FROM expression)` Teradata function.
+- [Function]: The `microsoft.rtrim` script installs a function that emulates the `TRIM(TRAILING 'trim_characters' FROM expression)` Teradata function.
+
+### v0.8.0.0 (August 4th, 2020)
+
+Version 0.8.0.0 is the initial public release of the Azure Synapse SQL Extension toolkit.

--- a/SQL/Extension/deploy.bat
+++ b/SQL/Extension/deploy.bat
@@ -6,7 +6,7 @@ setlocal
 set _secure_password=**********
 
 ECHO.
-ECHO Azure Synapse SQL Extension toolkit v0.8.0.0 deployment script
+ECHO Azure Synapse SQL Extension toolkit v0.9.0.0 deployment script
 
 IF NOT "%~4"=="" IF "%~5"=="" GOTO Deploy
 ECHO The deploy script requires the following parameters:
@@ -48,13 +48,16 @@ ECHO Deploying functions
 REM Functions
 sqlcmd -S %_server% -d %_database% -U %_username% -P %_password% -I -i .\functions\microsoft.acosh.sql
 sqlcmd -S %_server% -d %_database% -U %_username% -P %_password% -I -i .\functions\microsoft.asinh.sql
+sqlcmd -S %_server% -d %_database% -U %_username% -P %_password% -I -i .\functions\microsoft.btrim.sql
 sqlcmd -S %_server% -d %_database% -U %_username% -P %_password% -I -i .\functions\microsoft.dayoccurrence_of_month.sql
 sqlcmd -S %_server% -d %_database% -U %_username% -P %_password% -I -i .\functions\microsoft.initcap.sql
 sqlcmd -S %_server% -d %_database% -U %_username% -P %_password% -I -i .\functions\microsoft.instr.sql
 sqlcmd -S %_server% -d %_database% -U %_username% -P %_password% -I -i .\functions\microsoft.lpad.sql
+sqlcmd -S %_server% -d %_database% -U %_username% -P %_password% -I -i .\functions\microsoft.ltrim.sql
 sqlcmd -S %_server% -d %_database% -U %_username% -P %_password% -I -i .\functions\microsoft.months_between.sql
 sqlcmd -S %_server% -d %_database% -U %_username% -P %_password% -I -i .\functions\microsoft.next_day.sql
 sqlcmd -S %_server% -d %_database% -U %_username% -P %_password% -I -i .\functions\microsoft.rpad.sql
+sqlcmd -S %_server% -d %_database% -U %_username% -P %_password% -I -i .\functions\microsoft.rtrim.sql
 
 ECHO Deploying views
 

--- a/SQL/Extension/functions/Readme.md
+++ b/SQL/Extension/functions/Readme.md
@@ -6,6 +6,9 @@ The `microsoft.acosh` script installs a function that emulates the `ACOSH(expres
 ## microsoft.asinh
 The `microsoft.asinh` script installs a function that emulates the `ASINH(expression)` ANSI function.
 
+## microsoft.btrim
+The `microsoft.btrim` script installs a function that emulates the `TRIM(BOTH 'trim_characters' FROM expression)` Teradata function.
+
 ## microsoft.dayoccurrence_of_month
 The `microsoft.dayoccurrence_of_month` script installs a function that emulates the `DAYOCCURRENCE_OF_MONTH(expression)` Teradata function.
 
@@ -16,13 +19,19 @@ The `microsoft.initcap` script installs a function that emulates the `INITCAP(ex
 The `microsoft.instr` script installs a function that emulates the `INSTR(expression, substring, position, occurrence)` function found in Oracle and Teradata.
 
 ## microsoft.lpad
-The `microsoft.lpad` script installs a function that emulates the `LPAD(expression, length [, fill])` TERADATA function.
+The `microsoft.lpad` script installs a function that emulates the `LPAD(expression, length [, fill])` Teradata function.
+
+## microsoft.ltrim
+The `microsoft.ltrim` script installs a function that emulates the `TRIM(LEADING 'trim_characters' FROM expression)` Teradata function.
 
 ## microsoft.months_between
-The `microsoft.months_between` script installs a function that emulates the `MONTHS_BETWEEN(date_expression, date_expression)` TERADATA function.
+The `microsoft.months_between` script installs a function that emulates the `MONTHS_BETWEEN(date_expression, date_expression)` Teradata function.
 
 ## microsoft.next_day
-The `microsoft.next_day` script installs a function that emulates the `NEXT_DAY(date_expression, day_value)` TERADATA function.
+The `microsoft.next_day` script installs a function that emulates the `NEXT_DAY(date_expression, day_value)` Teradata function.
 
 ## microsoft.rpad
-The `microsoft.rpad` script installs a function that emulates the `RPAD(expression, length [, fill])` TERADATA function.
+The `microsoft.rpad` script installs a function that emulates the `RPAD(expression, length [, fill])` Teradata function.
+
+## microsoft.rtrim
+The `microsoft.rtrim` script installs a function that emulates the `TRIM(TRAILING 'trim_characters' FROM expression)` Teradata function.

--- a/SQL/Extension/functions/microsoft.btrim.sql
+++ b/SQL/Extension/functions/microsoft.btrim.sql
@@ -1,0 +1,18 @@
+IF EXISTS (SELECT * FROM sys.objects WHERE schema_id=SCHEMA_ID('microsoft') AND name = N'btrim')
+    DROP FUNCTION microsoft.btrim;
+GO
+
+CREATE FUNCTION microsoft.btrim(@expression NVARCHAR(MAX), @characters VARCHAR(32) = ' ')
+RETURNS NVARCHAR(MAX)
+WITH SCHEMABINDING
+AS
+BEGIN
+
+	-- Fast opt out
+	IF (@characters IS NULL OR TRIM(@characters) = '')
+		RETURN @expression
+
+	RETURN
+		microsoft.ltrim(microsoft.rtrim(@expression, @characters), @characters)
+END
+GO

--- a/SQL/Extension/functions/microsoft.ltrim.sql
+++ b/SQL/Extension/functions/microsoft.ltrim.sql
@@ -1,0 +1,26 @@
+IF EXISTS (SELECT * FROM sys.objects WHERE schema_id=SCHEMA_ID('microsoft') AND name = N'ltrim')
+    DROP FUNCTION microsoft.ltrim;
+GO
+
+CREATE FUNCTION microsoft.ltrim(@expression NVARCHAR(MAX), @characters VARCHAR(32) = ' ')
+RETURNS NVARCHAR(MAX)
+WITH SCHEMABINDING
+AS
+BEGIN
+
+	-- Fast opt out
+	IF (@characters IS NULL OR TRIM(@characters) = '')
+		RETURN @expression
+
+	DECLARE @character_length INT = DATALENGTH(@characters);
+	SET @characters = REPLACE(@characters, '%', '[%]');
+	SET @characters = REPLACE(@characters, '_', '[_]');
+	SET @characters = @characters + '%';
+
+	RETURN
+		CASE PATINDEX(@characters, @expression)
+			WHEN 0 THEN @expression
+			ELSE SUBSTRING(@expression, PATINDEX(@characters, @expression) + @character_length, DATALENGTH(@expression))
+		END
+END
+GO

--- a/SQL/Extension/functions/microsoft.rtrim.sql
+++ b/SQL/Extension/functions/microsoft.rtrim.sql
@@ -1,0 +1,27 @@
+IF EXISTS (SELECT * FROM sys.objects WHERE schema_id=SCHEMA_ID('microsoft') AND name = N'rtrim')
+    DROP FUNCTION microsoft.rtrim;
+GO
+
+CREATE FUNCTION microsoft.rtrim(@expression NVARCHAR(MAX), @characters VARCHAR(32) = ' ')
+RETURNS NVARCHAR(MAX)
+WITH SCHEMABINDING
+AS
+BEGIN
+
+	-- Fast opt out
+	IF (@characters IS NULL OR TRIM(@characters) = '')
+		RETURN @expression
+
+	DECLARE @character_length INT = DATALENGTH(@characters);
+	SET @characters = REVERSE(@characters);
+	SET @characters = REPLACE(@characters, '%', '[%]');
+	SET @characters = REPLACE(@characters, '_', '[_]');
+	SET @characters = @characters + '%';
+
+	RETURN
+		CASE PATINDEX(@characters, REVERSE(@expression))
+			WHEN 0 THEN @expression
+			ELSE REVERSE(SUBSTRING(REVERSE(@expression), PATINDEX(@characters, REVERSE(@expression)) + @character_length, DATALENGTH(@expression)))
+		END
+END
+GO

--- a/SQL/Extension/views/microsoft.dw_extension_version.sql
+++ b/SQL/Extension/views/microsoft.dw_extension_version.sql
@@ -5,5 +5,5 @@ CREATE VIEW microsoft.dw_extension_version
 AS
 
 	SELECT
-		[version] =	CAST('0.8.0.0' AS VARCHAR(20));
+		[version] =	CAST('0.9.0.0' AS VARCHAR(20));
 GO


### PR DESCRIPTION
Version 0.9.0.0 adds the following:

- [_Function_]: The `microsoft.btrim` script installs a function that emulates the `TRIM(BOTH 'trim_characters' FROM expression)` Teradata function.
- [_Function_]: The `microsoft.ltrim` script installs a function that emulates the `TRIM(LEADING 'trim_characters' FROM expression)` Teradata function.
- [_Function_]: The `microsoft.rtrim` script installs a function that emulates the `TRIM(TRAILING 'trim_characters' FROM expression)` Teradata function.