### PR TITLE
add customer-managed key (CMK) to deploy templates

### DIFF
--- a/Manage/DeployWorkspace/azuredeploy.json
+++ b/Manage/DeployWorkspace/azuredeploy.json
@@ -14,7 +14,19 @@
         "tagValues": {
             "defaultValue": {"Created with":"Synapse Azure Resource Manager deploment template"},
             "type": "Object"
+        },
+        "keyVaultKeyUri": {
+            "defaultValue": "",
+            "type": "String",
+            "metadata": {
+                "description": "The uri to a key in your Key Vault to add a second layer of encryption on top of what is provided by default (optional)."
+            }
         }
+    },
+    "variables": {
+      "withoutCmk": "{}",
+      "withCmk": "[concat('{\"cmk\":{\"key\":{\"name\":\"default\", \"keyVaultUrl\":\"', parameters('keyVaultKeyUri'), '\"}}}')]",
+      "encryption": "[json(if(empty(parameters('keyVaultKeyUri')), variables('withoutCmk'), variables('withCmk')))]"
     },
     "resources": [
         {
@@ -47,7 +59,8 @@
                 "sqlAdministratorLogin":{"value": "[parameters('sqlAdministratorLogin')]"},
                 "sqlAdministratorPassword":{"value": "[parameters('sqlAdministratorPassword')]"},
                 "defaultDataLakeStorageAccountName":{"value": "[replace(parameters('name'),'-','')]"},
-                "tagValues":{"value": "[parameters('tagValues')]"}
+                "tagValues":{"value": "[parameters('tagValues')]"},
+                "encryption": "[variables('encryption')]"
               }
             },
             "dependsOn": [

--- a/Manage/DeployWorkspace/readme.md
+++ b/Manage/DeployWorkspace/readme.md
@@ -9,4 +9,18 @@ This template deploys Azure Synapse workspace with underlying Data Lake Storage.
 <img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.png"/>
 </a>
 
+## Parameters
+
+| name | required | description |
+--- | --- | ---
+| Name | yes | name to use for your new Azure Synapse workspace and Data Lake Storage account |
+| Sql Administrator Login | yes | SQL administrator login name for workspace SQL active directory |
+| Sql Administrator Password | yes | SQL administrator login password for workspace SQL active directory |
+| Tag Values | no | resource tags |
+| Key Vault Key Uri | no | customer-managed key uri from Key Vault for double encryption |
+
+NOTE: If you want to provide a customer-managed key (CMK) from Key Vault for double encryption, you can get the uri from the portal. See [here](https://docs.microsoft.com/en-us/azure/key-vault/secrets/quick-create-portal#retrieve-a-secret-from-key-vault) for details on how to get the uri from Key Vault and [here](https://docs.microsoft.com/en-us/azure/synapse-analytics/security/workspaces-encryption) for more information on encryption in Azure Synapse in general.
+
+---
+
 `Tags: Azure, Synapse, Analytics`

--- a/Manage/DeployWorkspace/workspace/azuredeploy.json
+++ b/Manage/DeployWorkspace/workspace/azuredeploy.json
@@ -48,6 +48,13 @@
             "metadata": {
                 "description": "Do not change this value if Data Lake Storage is placed in the same region as Synapse Workspace(recommended)."
             }
+        },
+        "encryption": {
+            "defaultValue": {},
+            "type": "Object",
+            "metadata": {
+                "description": "The encryption object containing your customer-managed key used for double encryption (optional)."
+            }
         }
     },
     "variables": {
@@ -73,7 +80,8 @@
                     "computeSubnetId": ""
                 },
                 "sqlAdministratorLogin": "[parameters('sqlAdministratorLogin')]",
-                "sqlAdministratorLoginPassword": "[parameters('sqlAdministratorPassword')]"
+                "sqlAdministratorLoginPassword": "[parameters('sqlAdministratorPassword')]",
+                "encryption": "[parameters('encryption')]"
             },
             "resources": [
                 {

--- a/Manage/DeployWorkspace/workspace/azuredeploy.parameters.json
+++ b/Manage/DeployWorkspace/workspace/azuredeploy.parameters.json
@@ -37,6 +37,9 @@
         },
         "storageLocation": {
             "value": ""
+        },
+        "encryption": {
+            "value": {}
         }
     }
 }


### PR DESCRIPTION
Add a new 'keyVaultKeyUri' param to azuredeploy.json. It creates a new 'encryption' variable, that is passes into workspace/azuredeploy.json, which then applies it to the newly created Synapse workspace. The default empty string for 'keyVaultKeyUri' results in an empty dict for 'encryption', which leaves things unchanged from how they are now. Otherwise, the customer-managed key (CMK) will be applied.