### PR TITLE
Sample Spark .NET notebook to read from Event Hubs

### DIFF
--- a/Notebooks/Spark.NET C#/Stream-Processor.ipynb
+++ b/Notebooks/Spark.NET C#/Stream-Processor.ipynb
@@ -1,0 +1,297 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Stream processing\r\n",
+        "\r\n",
+        "This notebook shows how to connect to an Event Hub, read the stream and process the messages using .NET for Apache Spark on Azure Synapse Analytics.\r\n",
+        "\r\n",
+        "In order to reproduce a common use case, we have the code for the following steps: \r\n",
+        "\r\n",
+        "- Read stream from Event Hubs\r\n",
+        "- Decompress gzip body\r\n",
+        "- Apply schema\r\n",
+        "- Apply stream processing\r\n",
+        "- (*optional*) Save to Delta table\r\n",
+        "\r\n",
+        "Please refer to the official documentation for additional details:\r\n",
+        "- [.NET for Apache Spark](https://dotnet.microsoft.com/apps/data/spark)\r\n",
+        "- [.NET for Spark on Azure Synapse Analytics](https://docs.microsoft.com/en-us/azure/synapse-analytics/spark/spark-dotnet)\r\n",
+        "- [.NET APIs for Spark](https://docs.microsoft.com/en-us/dotnet/api/microsoft.spark?view=spark-dotnet)\r\n",
+        "- [UDFs on .NET for Spark](https://docs.microsoft.com/en-us/dotnet/spark/how-to-guides/udf-guide)\r\n"
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Parameters\r\n",
+        "These are just placeholders, the real values can be either inserted here before running the notebook, or even better overwritten using pipeline variables: https://docs.microsoft.com/en-us/azure/synapse-analytics/spark/apache-spark-development-using-notebooks?tabs=preview#assign-parameters-values-from-a-pipeline"
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "var eh_connstr = \"<connection string of your Event Hub>\";\r\n",
+        "var eh_consumergroup = \"<consumer group of your Event Hub you want to use to receive the messages>\";\r\n",
+        "var eh_data_type = \"<can be arbitrary, its main goal is to differentiate between message checkpoint locations>\"; //The idea here is to use the type of data you are reading to create the checkpoint location for your delta table."
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {
+        "tags": [
+          "parameters"
+        ]
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "\r\n",
+        "var eh_checkpoint_location = $\"/delta/_checkpoints/{eh_data_type}/\";\r\n",
+        "if(eh_connstr == \"placeholder\") \r\n",
+        "{\r\n",
+        "    Console.Error.WriteLine(\"Please insert your EH connection string in the parameters\");\r\n",
+        "}\r\n",
+        "\r\n",
+        "Console.WriteLine(eh_checkpoint_location);"
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Connect to Event Hub\r\n",
+        "We will now connect to Event Hub and create a streaming dataframe (**streamingDf**). \r\n",
+        "\r\n",
+        "We need to manually encrypt the connection string. \r\n"
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "// The connection string must be encrypted\r\n",
+        "\r\n",
+        "using Microsoft.Spark.Interop;\r\n",
+        "var eventHubConnectionStringEncrypted = (string)SparkEnvironment.JvmBridge.CallStaticJavaMethod(\"org.apache.spark.eventhubs.EventHubsUtils\", \"encrypt\", eh_connstr);"
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "// Connect to EH\r\n",
+        "var ehConf = new Dictionary<string, string>();\r\n",
+        "ehConf.Add(\"eventhubs.connectionString\", eventHubConnectionStringEncrypted);\r\n",
+        "ehConf.Add(\"eventhubs.consumerGroup\", eh_consumergroup);\r\n",
+        "\r\n",
+        "DataFrame streamingDf = spark\r\n",
+        "    .ReadStream()\r\n",
+        "    .Format(\"eventhubs\")\r\n",
+        "    .Options(ehConf)\r\n",
+        "    .Load();"
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Decompress gzip body\r\n",
+        "\r\n",
+        "The message body is compressed (gzip). We need to create a UDF to decompress each row in our **streamingDF**.\r\n",
+        "We need to add the *SharpZipLib* nuget package. [Here](https://documentation.help/ICSharpCode.SharpZipLib/documentation.pdf) you can find more information about the library.\r\n"
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "// We use SharpZipLib to decompress the body\r\n",
+        "#r \"nuget:SharpZipLib\""
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "using System.IO;\r\n",
+        "using ICSharpCode.SharpZipLib.GZip;\r\n",
+        "\r\n",
+        "// Define an UDF to decompress EH body\r\n",
+        "public static string DecompressFunction(byte[] data)\r\n",
+        "{\r\n",
+        "    using var source = new MemoryStream(data);\r\n",
+        "    using GZipInputStream zipStream = new GZipInputStream(source);\r\n",
+        "    using StreamReader sr = new StreamReader(zipStream);\r\n",
+        "    return sr.ReadToEnd();\r\n",
+        "}\r\n",
+        "\r\n",
+        "Func<Column, Column> DecompressAvro = Udf<byte[], string>(DecompressFunction);"
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "// Decompress EH body\r\n",
+        "var decompDf = streamingDf.WithColumn(\"DecompressedBody\", DecompressAvro(streamingDf[\"body\"]));"
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Apply schema to EH messages\n",
+        "\n",
+        "The schema of the decompressed body is defined and applied below.\n"
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "// Define a schema for EH body\r\n",
+        "using Microsoft.Spark.Sql.Types;\r\n",
+        "var schema = new StructType(new[]\r\n",
+        "{\r\n",
+        "    new StructField(\"DataType\", new StringType()),\r\n",
+        "    new StructField(\"MessageContent\", new StringType()),\r\n",
+        "    new StructField(\"MessageId\", new StringType()),\r\n",
+        "    new StructField(\"Timestamp\", new TimestampType()),\r\n",
+        "});"
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "// Parse json\r\n",
+        "var jsonDf = decompDf\r\n",
+        "    .WithColumn(\"jsonBody\", FromJson(decompDf[\"DecompressedBody\"], schema.SimpleString))\r\n",
+        "    .Select(\"enqueuedTime\", \"jsonBody\", \"body\");"
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Process the stream\r\n",
+        "\r\n",
+        "Extract meaningful data from the decompressed body and add them as separate columns.\r\n"
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "// Process stream: Extract meaningful fields\r\n",
+        "var finalDf = jsonDf\r\n",
+        "    .WithColumn(\"MessageId\", jsonDf[\"jsonBody\"].GetField(\"MessageId\"))\r\n",
+        "    .WithColumn(\"DocType\", Lit(eh_data_type))\r\n",
+        "    .WithColumn(\"SourceType\", jsonDf[\"jsonBody\"].GetField(\"DataType\"))\r\n",
+        "    .WithColumn(\"TimeStamp\", jsonDf[\"jsonBody\"].GetField(\"Timestamp\"));"
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Save as a Delta Table\r\n",
+        "Save the dataframe as a delta table, which will be created if does not exist.\r\n"
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "// ToTable API is available from Spark 3.1\r\n",
+        "var deltaStream = finalDf\r\n",
+        "    .WriteStream()\r\n",
+        "    .Format(\"delta\")\r\n",
+        "    .OutputMode(\"append\")\r\n",
+        "    .Option(\"checkpointLocation\", eh_checkpoint_location)\r\n",
+        "    .ToTable(\"deltatablesample\");"
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "spark.Sql(\"SELECT * FROM deltatablesample LIMIT 10\").Show();"
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Debug\r\n",
+        "\r\n",
+        "The following cells can be used to verify if the data is correclty streamed and manipulated in any of the steps above.\r\n",
+        "\r\n",
+        "Just add those 2 cells after the manipulation you need to test, replace the name of the DataStreamWriter (here *finalDf*) with the one you want to test, and run both cells. Please notice that the second one might look like it's empty in the beginning, but it just needs few seconds before being able to show the actual results. \r\n"
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "// DEBUG\r\n",
+        "var sQuery = finalDf.WriteStream().Format(\"memory\").QueryName(\"finalDf\").Start();"
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "// DEBUG\r\n",
+        "spark.Sql(\"select * from finalDf\").Show();"
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {}
+    }
+  ],
+  "metadata": {
+    "language_info": {
+      "name": "csharp"
+    },
+    "kernelspec": {
+      "name": "synapse_sparkdotnet",
+      "display_name": "csharp"
+    },
+    "save_output": true,
+    "synapse_widget": {
+      "version": "0.1",
+      "state": {}
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}


### PR DESCRIPTION
This notebook shows how to connect to an Event Hub, read the stream and process the messages using .NET for Apache Spark on Azure Synapse Analytics.

This notebook shows how to do the following:

- Read stream from Event Hubs
- Decompress gzip body
- Apply schema
- Apply stream processing
- (optional) Save to Delta table